### PR TITLE
Add headers to Firebase function response

### DIFF
--- a/server/functions/index.js
+++ b/server/functions/index.js
@@ -53,6 +53,11 @@ exports.transcriptAudio = functions.https.onRequest(async (req, res) => {
 
                 fs.unlinkSync(tmpFilePath);
 
+                res.set(
+                    "Access-Control-Allow-Origin",
+                    "https://talk-text.netlify.app"
+                );
+                res.set("Access-Control-Allow-Credentials", "true");
                 res.status(200).send({ data: transcription.text });
             } catch (error) {
                 console.error("Error on transcription:", error);
@@ -63,6 +68,11 @@ exports.transcriptAudio = functions.https.onRequest(async (req, res) => {
 
         busboy.on("error", (error) => {
             console.error("Busboy error:", error);
+            res.set(
+                "Access-Control-Allow-Origin",
+                "https://talk-text.netlify.app"
+            );
+            res.set("Access-Control-Allow-Credentials", "true");
             res.status(500).send({ error: "Busboy Error" });
         });
 


### PR DESCRIPTION
## Description

Fix the Cors bug due to a lack of headers on the Firebase function response.

## **Related Issue:**

N/A

## **Main changes explained:**

- Add headers to Firebase function response in file index.js

## **How to test:**

1. check `https://talk-text.netlify.app/`
2. record an audio
3. check if you receive a response properly
4. If received, everything worked as intended